### PR TITLE
 docs(README.md): update kubectl command to use the correct namespace for getting events

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -9,7 +9,7 @@ kubectl logs --tail=200 -l app=fos -n fos
 ```
 
 ```bash
-kubectl get events -n flux-system --field-selector type=Warning
+kubectl get events -n cluster-config --field-selector type=Warning
 ```
 
 ```bash


### PR DESCRIPTION
The changes in this commit message are related to improving the documentation and functionality of a Terraform project. The first change is updating a `kubectl` command in the README file to use the correct namespace when retrieving events. This ensures that users can easily troubleshoot any issues that may arise during deployment or operation of the project.

The second change is not explicitly mentioned in the diff output, but it could be inferred from the context of the updated `kubectl` command. It's possible that the namespace used for retrieving events was also changed from `flux-system` to `cluster-config`. This would require updating any relevant configuration files or variables within the project to reflect this change, and may have been necessary in order to ensure that the updated `kubectl` command works correctly.
